### PR TITLE
Support missing hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,27 @@ The complete list of variables that will be set for each hook is as follows.
         STATUSCODE
         REASON
         REQTYPE
+        HEADERS
     
     exit-hook
-        (none)
+        ERROR
+        
+    startup-hook
+        (no variables set)
+    
+    generate-csr
+        DOMAIN
+        CERTDIR
+        ALTNAMES
+        
+    deploy-ocsp
+        DOMAIN
+        OCSPFILE
+        TIMESTAMP
+
+    sync-cert
+        KEYFILE
+        CERTFILE
+        FULLCHAINFILE
+        CHAINFILE
+        REQUESTFILE

--- a/code-rack
+++ b/code-rack
@@ -39,7 +39,7 @@ case $handler in
         export KEYFILE="$1" CERTFILE="$2" FULLCHAINFILE="$3" CHAINFILE="$4" REQUESTFILE="$5"
         ;;
     exit_hook)
-        export ERROR="$1"
+        export ERROR="${1:-}"
         ;;
     *)
         echo "Unknown hook: $handler" >&2

--- a/code-rack
+++ b/code-rack
@@ -24,9 +24,22 @@ case $handler in
         export DOMAIN="$1" RESPONSE="$2"
         ;;
     request_failure)
-        export STATUSCODE="$1" REASON="$2" REQTYPE="$3"
+        export STATUSCODE="$1" REASON="$2" REQTYPE="$3" HEADERS="$4"
+        ;;
+    startup_hook)
+        # No variables for this one
+        ;;
+    generate_csr)
+        export DOMAIN="$1" CERTDIR="$2" ALTNAMES="$3"
+        ;;
+    deploy_ocsp)
+        export DOMAIN="$1" OCSPFILE="$2" TIMESTAMP="$3"
+        ;;
+    sync_cert)
+        export KEYFILE="$1" CERTFILE="$2" FULLCHAINFILE="$3" CHAINFILE="$4" REQUESTFILE="$5"
         ;;
     exit_hook)
+        export ERROR="$1"
         ;;
     *)
         echo "Unknown hook: $handler" >&2


### PR DESCRIPTION
Added the missing hooks (startup_hook, generate_csr, deploy_ocsp, sync_cert, exit_hook) and missing variable (HEADERS) to request_failure.